### PR TITLE
Fix EndOfTranscript event firing twice and update example

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,14 @@ import { RealtimeSession } from 'speechmatics';
 
 // imports helpful for the file streaming
 const fs = require('fs');
+const path = require('path');
 
 // init the session
 const session = new RealtimeSession(YOUR_API_KEY);
 
 //add listeners
 session.addListener('RecognitionStarted', () => {
-  console.log('session started');
+  console.log('RecognitionStarted');
 });
 
 session.addListener('Error', (error) => {
@@ -123,21 +124,23 @@ session.addListener('Error', (error) => {
 });
 
 session.addListener('AddTranscript', (message) => {
-  console.log('message', message);
+  console.log('AddTranscript', message);
 });
 
 session.addListener('AddPartialTranscript', (message) => {
-  console.log('message', message);
+  console.log('AddPartialTranscript', message);
 });
 
 session.addListener('EndOfTranscript', () => {
-  console.log('Session stopped');
+  console.log('EndOfTranscript');
 });
 
 //start session which is an async method
 session.start().then(() => {
   //prepare file stream
-  const fileStream = fs.createReadStream('examples/example_files/example.wav');
+  const fileStream = fs.createReadStream(
+    path.join(__dirname, 'example_files/example.wav'),
+  );
 
   //send it
   fileStream.on('data', (sample) => {
@@ -172,7 +175,7 @@ const session = new RealtimeSession(YOUR_JWT);
 
 //add listeners
 session.addListener('RecognitionStarted', () => {
-  console.log('session started');
+  console.log('RecognitionStarted');
 });
 
 session.addListener('Error', (error) => {
@@ -180,15 +183,15 @@ session.addListener('Error', (error) => {
 });
 
 session.addListener('AddTranscript', (message) => {
-  console.log('message', message);
+  console.log('AddTranscript', message);
 });
 
 session.addListener('AddPartialTranscript', (message) => {
-  console.log('message', message);
+  console.log('AddPartialTranscript', message);
 });
 
 session.addListener('EndOfTranscript', () => {
-  console.log('Session stopped');
+  console.log('EndOfTranscript');
 });
 
 //start session which is an async method
@@ -258,6 +261,6 @@ We'd love to see your contributions! Please read our [contributing guidelines](.
 
 ## Feedback & Help
 
-- For feature requests or bugs [open an issue](https://github.com/speechmatics/speechmatics-js/issues/new) 
+- For feature requests or bugs [open an issue](https://github.com/speechmatics/speechmatics-js-sdk/issues/new) 
 - To provide direct feedback, email us at [devrel@speechmatics.com](mailto:devrel@speechmatics.com)
 - We're [@speechmatics](https://twitter.com/Speechmatics) on Twitter too!

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ session.addListener('AddPartialTranscript', (message) => {
   console.log('message', message);
 });
 
-session.addListener('EndOfStream', () => {
+session.addListener('EndOfTranscript', () => {
   console.log('Session stopped');
 });
 
@@ -187,7 +187,7 @@ session.addListener('AddPartialTranscript', (message) => {
   console.log('message', message);
 });
 
-session.addListener('EndOfStream', () => {
+session.addListener('EndOfTranscript', () => {
   console.log('Session stopped');
 });
 

--- a/examples/example_rt_node.js
+++ b/examples/example_rt_node.js
@@ -53,7 +53,7 @@ session
     });
 
     //end the session
-    fileStream.on('end', async () => {
+    fileStream.on('end', () => {
       session.stop();
     });
   })

--- a/examples/example_rt_node.js
+++ b/examples/example_rt_node.js
@@ -12,7 +12,7 @@ if (parseInt(process.version.match(/(?:v)([0-9]{2})/)[1]) < 18) {
 const session = new RealtimeSession(process.env.API_KEY);
 
 session.addListener('RecognitionStarted', () => {
-  console.log('session started');
+  console.log('RecognitionStarted');
 });
 
 session.addListener('Error', (error) => {
@@ -20,11 +20,11 @@ session.addListener('Error', (error) => {
 });
 
 session.addListener('AddTranscript', (message) => {
-  console.log('transcript> ', message.metadata.transcript);
+  console.log('AddTranscript', message.metadata.transcript);
 });
 
 session.addListener('AddPartialTranscript', (message) => {
-  // console.log('partial', message);
+  // console.log('AddPartialTranscript', message);
 });
 
 session.addListener('EndOfTranscript', () => {
@@ -49,6 +49,7 @@ session
 
     //send it
     fileStream.on('data', (sample) => {
+      console.log('sending audio', sample.length);
       session.sendAudio(sample);
     });
 

--- a/examples/example_rt_node.js
+++ b/examples/example_rt_node.js
@@ -5,7 +5,9 @@ const path = require('path');
 const { RealtimeSession } = require('../dist');
 
 if (parseInt(process.version.match(/(?:v)([0-9]{2})/)[1]) < 18) {
-  throw new Error("Requires node 18 or higher. If this isn't possible, see our documentation about polyfilling");
+  throw new Error(
+    "Requires node 18 or higher. If this isn't possible, see our documentation about polyfilling",
+  );
 }
 const session = new RealtimeSession(process.env.API_KEY);
 
@@ -25,8 +27,8 @@ session.addListener('AddPartialTranscript', (message) => {
   // console.log('partial', message);
 });
 
-session.addListener('EndOfStream', () => {
-  console.log('Session stopped');
+session.addListener('EndOfTranscript', () => {
+  console.log('EndOfTranscript');
 });
 
 session
@@ -41,7 +43,9 @@ session
   })
   .then(() => {
     //prepare file stream
-    const fileStream = fs.createReadStream(path.join(__dirname, 'example_files/example.wav'));
+    const fileStream = fs.createReadStream(
+      path.join(__dirname, 'example_files/example.wav'),
+    );
 
     //send it
     fileStream.on('data', (sample) => {
@@ -49,7 +53,7 @@ session
     });
 
     //end the session
-    fileStream.on('end', () => {
+    fileStream.on('end', async () => {
       session.stop();
     });
   })

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "speechmatics",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Speechmatics Javascript Libraries",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build:clean": "rm -rf dist",
     "build:cjs": "./build.js",
@@ -15,7 +17,9 @@
     "check": "npx rome check .",
     "format": "npx rome format --write ."
   },
-  "precommit": ["check"],
+  "precommit": [
+    "check"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/speechmatics/speechmatics-js-sdk.git"

--- a/src/management-platform/auth.ts
+++ b/src/management-platform/auth.ts
@@ -8,8 +8,8 @@ export default async function getShortLivedToken(
 ) {
   if (typeof window !== 'undefined') {
     console.warn(
-      "Requesting a short lived token from a browser is not recommended. \
-    More info at https://github.com/speechmatics/speechmatics-js#readme",
+      'Requesting a short lived token from a browser is not recommended. \
+    More info at https://github.com/speechmatics/speechmatics-js#readme',
     );
   }
   const jsonResponse = await request<{ key_value: string }>(

--- a/src/realtime/client.ts
+++ b/src/realtime/client.ts
@@ -69,9 +69,6 @@ export class RealtimeSession {
       onError: (data: ModelError) => {
         this.emitter.emit(MessagesEnum.Error, data);
       },
-      onDisconnect: () => {
-        this.emitter.emit(MessagesEnum.EndOfTranscript, this);
-      },
     };
   }
 

--- a/src/realtime/handlers.ts
+++ b/src/realtime/handlers.ts
@@ -56,7 +56,6 @@ export class RealtimeSocketHandler {
   ): Promise<void> {
     this.seqNoIn = 0;
 
-
     return this.socketWrap.connect(runtimeURL, runtimeKey, appId);
   }
 
@@ -161,7 +160,6 @@ export class RealtimeSocketHandler {
         throw new Error('Unexpected message');
     }
   };
-
 
   private onSocketDisconnect = () => {
     this.sub.onDisconnect?.();


### PR DESCRIPTION
Adds `EndOfTranscript` event to node example
Removes `EndOfStream` event as this is a client event sent to the server not an event received by the client
Stops sending `EndOfTranscript` event on the socket `onDisconnect` event as this results in 2 `EndOfTranscript` events being received by the client.
