### PR TITLE
Allow Blob to be passed directly when sending audio buffer

### DIFF
--- a/src/realtime/browser.ts
+++ b/src/realtime/browser.ts
@@ -26,11 +26,7 @@ export class WebSocketWrapper implements ISocketWrapper {
       throw new Error('window is undefined - are you running in a browser?');
   }
 
-  async connect(
-    runtimeURL: string,
-    authToken?: string,
-    appId?: string,
-  ): Promise<void> {
+  async connect(runtimeURL: string, authToken?: string, appId?: string): Promise<void> {
     const url = addQueryParamsToUrl(runtimeURL, {
       jwt: authToken,
       [SM_SDK_PARAM_NAME]: getSmSDKVersion(),
@@ -68,7 +64,7 @@ export class WebSocketWrapper implements ISocketWrapper {
     });
   }
 
-  sendAudioBuffer(buffer: ArrayBufferLike): void {
+  sendAudioBuffer(buffer: ArrayBufferLike | Blob): void {
     if (this.socket && this.isOpen()) {
       this.socket.send(buffer);
     } else console.error('Tried to send audio when socket was closed');
@@ -77,8 +73,7 @@ export class WebSocketWrapper implements ISocketWrapper {
   sendMessage(message: string): void {
     if (this.socket && this.isOpen()) {
       this.socket.send(message);
-    } else
-      console.error('Tried to send message when socket was closed', message);
+    } else console.error('Tried to send message when socket was closed', message);
   }
 
   isOpen(): boolean {

--- a/src/realtime/node.ts
+++ b/src/realtime/node.ts
@@ -27,19 +27,14 @@ export class NodeWebSocketWrapper implements ISocketWrapper {
       throw new Error('process is undefined - are you running in node?');
   }
 
-  async connect(
-    runtimeURL: string,
-    authToken?: string,
-    appId?: string,
-  ): Promise<void> {
+  async connect(runtimeURL: string, authToken?: string, appId?: string): Promise<void> {
     const url = addQueryParamsToUrl(runtimeURL, {
       [SM_SDK_PARAM_NAME]: getSmSDKVersion(),
       [SM_APP_PARAM_NAME]: appId,
     });
     try {
       let options: ClientOptions | ClientRequestArgs | undefined;
-      if (authToken)
-        options = { headers: { Authorization: `Bearer ${authToken}` } };
+      if (authToken) options = { headers: { Authorization: `Bearer ${authToken}` } };
       this.socket = new WebSocket(url, {
         perMessageDeflate: false,
         ...options,
@@ -71,17 +66,21 @@ export class NodeWebSocketWrapper implements ISocketWrapper {
     });
   }
 
-  sendAudioBuffer(buffer: ArrayBufferLike): void {
+  sendAudioBuffer(data: ArrayBufferLike | Blob): void {
     if (this.socket && this.isOpen()) {
-      this.socket.send(buffer);
+      if (data instanceof Blob) {
+        // NOTE: Maybe we should add a log message about this potentially being poorer performance in Node
+        data.arrayBuffer().then((buf) => this.socket?.send(buf));
+      } else {
+        this.socket.send(data);
+      }
     } else console.error('tried to send audio when socket was closed');
   }
 
   sendMessage(message: string): void {
     if (this.socket && this.isOpen()) {
       this.socket.send(message);
-    } else
-      console.error('tried to send message when socket was closed', message);
+    } else console.error('tried to send message when socket was closed', message);
   }
 
   isOpen(): boolean {
@@ -111,7 +110,6 @@ export class NodeWebSocketWrapper implements ISocketWrapper {
 
   private handleSocketMessage = (message: MessageEvent): void => {
     if (message.data) this.onMessage?.(JSON.parse(message.data.toString()));
-    if (message instanceof Buffer)
-      this.onMessage?.(JSON.parse(message.toString()));
+    if (message instanceof Buffer) this.onMessage?.(JSON.parse(message.toString()));
   };
 }

--- a/src/types/socket-interface.ts
+++ b/src/types/socket-interface.ts
@@ -6,7 +6,7 @@ export interface ISocketWrapper {
   onDisconnect?: (event: CloseEvent) => void;
   connect(url: string, authToken?: string, appId?: string): Promise<void>;
   disconnect(): Promise<void>;
-  sendAudioBuffer(buffer: ArrayBufferLike): void;
+  sendAudioBuffer(buffer: ArrayBufferLike | Blob): void;
   sendMessage(message: string): void;
   isOpen(): boolean;
 }


### PR DESCRIPTION
- The browser websocket implementation accepts `Blob` natively: https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/send

- The node `ws` package does not currently, so this code calls the `arrayBuffer()` method before passing the data to the websocket. This may incur some performance cost due to the async nature. 