### PR TITLE
Allow optional file name when creating job

### DIFF
--- a/examples/example_batch.js
+++ b/examples/example_batch.js
@@ -5,6 +5,8 @@ const { Speechmatics } = require('../dist');
 const fs = require('fs');
 const path = require('path');
 
+const fileName = 'example.wav';
+
 if (parseInt(process.version.match(/(?:v)([0-9]{2})/)[1]) < 18) {
   throw new Error(
     "Requires node 18 or higher. If this isn't possible, see our documentation about polyfilling",
@@ -13,11 +15,15 @@ if (parseInt(process.version.match(/(?:v)([0-9]{2})/)[1]) < 18) {
 
 const sm = new Speechmatics(process.env.API_KEY);
 const inputFile = new Blob([
-  fs.readFileSync(path.join(__dirname, 'example_files', 'example.wav')),
+  fs.readFileSync(path.join(__dirname, 'example_files', fileName)),
 ]);
 
 sm.batch
-  .transcribe({ input: inputFile, transcription_config: { language: 'en' } })
+  .transcribe({
+    input: inputFile,
+    fileName,
+    transcription_config: { language: 'en' },
+  })
   .then(({ results }) => {
     console.log(results.map((r) => r.alternatives[0].content).join(' '));
   })

--- a/src/batch/client.ts
+++ b/src/batch/client.ts
@@ -106,6 +106,7 @@ export class BatchTranscription {
    */
   async transcribe({
     input,
+    fileName,
     transcription_config,
     translation_config,
     output_config,
@@ -119,6 +120,7 @@ export class BatchTranscription {
 
     const submitResponse = await this.createJob({
       input: fileOrFetchConfig,
+      fileName,
       transcription_config,
       translation_config,
       output_config,
@@ -160,6 +162,7 @@ export class BatchTranscription {
 
   async createJob({
     input,
+    fileName,
     transcription_config,
     translation_config,
     output_config,
@@ -180,7 +183,7 @@ export class BatchTranscription {
     if ('url' in input) {
       config.fetch_data = input;
     } else {
-      formData.append('data_file', input);
+      formData.append('data_file', input, fileName);
     }
     formData.append('config', JSON.stringify(config));
 
@@ -225,10 +228,20 @@ export type TranscriptionFormat = 'json-v2' | 'text' | 'srt';
 
 export type TranscribeConfig = Omit<JobConfig, 'type'> & {
   input: Blob | { fetch: DataFetchConfig };
+  /**
+   * Optional file name when passing a raw Blob.
+   * Note that when passing a `File` object, this is not necessary, as the File's name will be used.
+   */
+  fileName?: string;
   language?: ISO639_1_Language;
   format?: TranscriptionFormat;
 };
 
 export type CreateJobConfig = Omit<JobConfig, 'type'> & {
   input: Blob | DataFetchConfig;
+  /**
+   * Optional file name when passing a raw Blob.
+   * Note that when passing a `File` object, this is not necessary, as the File's name will be used.
+   */
+  fileName?: string;
 };

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -6,9 +6,10 @@ import path from 'path';
 
 dotenv.config();
 
+const exampleFileName = 'example.wav';
 const EXAMPLE_FILE = new Blob([
   fs.readFileSync(
-    path.join(__dirname, '..', 'examples', 'example_files', 'example.wav'),
+    path.join(__dirname, '..', 'examples', 'example_files', exampleFileName),
   ),
 ]);
 
@@ -17,9 +18,11 @@ describe('Testing batch capabilities', () => {
     const speechmatics = new Speechmatics(process.env.API_KEY as string);
     const transcription = await speechmatics.batch.transcribe({
       input: EXAMPLE_FILE,
+      fileName: exampleFileName,
       transcription_config: { language: 'en' },
     });
     expect(transcription).toBeDefined();
+    expect(transcription.job.data_name).toEqual(exampleFileName);
   }, 30000);
 
   it('lists jobs', async () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,8 @@
-import { RealtimeSession, AddTranscript } from '../dist';
+import {
+  RealtimeSession,
+  AddTranscript,
+  RetrieveTranscriptResponse,
+} from '../dist';
 import { Speechmatics } from '../dist';
 import dotenv from 'dotenv';
 import fs from 'fs';
@@ -22,7 +26,10 @@ describe('Testing batch capabilities', () => {
       transcription_config: { language: 'en' },
     });
     expect(transcription).toBeDefined();
-    expect(transcription.job.data_name).toEqual(exampleFileName);
+    expect(typeof transcription).toBe('object');
+    expect((transcription as RetrieveTranscriptResponse).job.data_name).toEqual(
+      exampleFileName,
+    );
   }, 30000);
 
   it('lists jobs', async () => {


### PR DESCRIPTION
This PR adds support for passing a `fileName` string when calling `transcribe` or `createJob`.

This is to handle the case where a user passes a raw `Blob` as opposed to a `File`. It will also be useful when we add support for `Buffer` or `ReadStream` inputs, which will also lack file name metadata.