### PR TITLE
Include src in published assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "build:clean": "rm -rf dist",


### PR DESCRIPTION
Source maps are currently included in published assets, but point to the src directory which is not included.