### PR TITLE
chore: bumped licence year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023, Cantab Research Ltd.
+Copyright (c) 2024, Cantab Research Ltd.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
 Bumped licence year (2023 -> 2024)