### PR TITLE
Fix audio event types

### DIFF
--- a/packages/real-time-client/models/audio-event-ended.ts
+++ b/packages/real-time-client/models/audio-event-ended.ts
@@ -12,6 +12,10 @@
  * Do not edit the class manually.
  */
 
+// May contain unused imports in some cases
+// @ts-ignore
+import type { AudioEventEndedEvent } from './audio-event-ended-event';
+
 /**
  *
  * @export
@@ -26,16 +30,10 @@ export interface AudioEventEnded {
   message?: AudioEventEndedMessageEnum;
   /**
    *
-   * @type {string}
+   * @type {AudioEventEndedEvent}
    * @memberof AudioEventEnded
    */
-  type?: string;
-  /**
-   *
-   * @type {number}
-   * @memberof AudioEventEnded
-   */
-  end_time?: number;
+  event?: AudioEventEndedEvent;
 }
 
 export const AudioEventEndedMessageEnum = {

--- a/packages/real-time-client/models/audio-event-started.ts
+++ b/packages/real-time-client/models/audio-event-started.ts
@@ -12,6 +12,10 @@
  * Do not edit the class manually.
  */
 
+// May contain unused imports in some cases
+// @ts-ignore
+import type { AudioEventStartedEvent } from './audio-event-started-event';
+
 /**
  *
  * @export
@@ -26,22 +30,10 @@ export interface AudioEventStarted {
   message?: AudioEventStartedMessageEnum;
   /**
    *
-   * @type {string}
+   * @type {AudioEventStartedEvent}
    * @memberof AudioEventStarted
    */
-  type?: string;
-  /**
-   *
-   * @type {number}
-   * @memberof AudioEventStarted
-   */
-  start_time?: number;
-  /**
-   *
-   * @type {number}
-   * @memberof AudioEventStarted
-   */
-  confidence?: number;
+  event?: AudioEventStartedEvent;
 }
 
 export const AudioEventStartedMessageEnum = {

--- a/packages/real-time-client/package.json
+++ b/packages/real-time-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechmatics/real-time-client",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Client for the Speechmatics real-time API",
   "main": "dist/index.js",
   "browser": "dist/index.browser.js",

--- a/packages/real-time-client/schema/realtime.yml
+++ b/packages/real-time-client/schema/realtime.yml
@@ -242,19 +242,24 @@ components:
           message:
             enum:
               - AudioEventStarted
-          type:
-            type: string
-          start_time:
-            type: number
-            format: float
-          confidence:
-            type: number
-            format: float
+          event:
+            type: object
+            properties:
+              type:
+                type: string
+              start_time:
+                type: number
+                format: float
+              confidence:
+                type: number
+                format: float
+            required:
+              - type
+              - start_time
+              - confidence
       required:
         - message
-        - type
-        - start_time
-        - confidence
+        - event
     AudioEventEnded:
       summary: End of an audio event detected.
       payload:
@@ -263,11 +268,18 @@ components:
           message:
             enum:
               - AudioEventEnded
-          type:
-            type: string
-          end_time:
-            type: number
-            format: float
+          event:
+            type: object
+            properties:
+              type:
+                type: string
+              end_time:
+                type: number
+                format: float
+            required:
+              - type
+              - end_time
+
       required:
         - message
         - type

--- a/packages/real-time-client/scripts/openapi-transformed.yaml
+++ b/packages/real-time-client/scripts/openapi-transformed.yaml
@@ -168,25 +168,38 @@ components:
         message:
           enum:
             - AudioEventStarted
-        type:
-          type: string
-        start_time:
-          type: number
-          format: float
-        confidence:
-          type: number
-          format: float
+        event:
+          type: object
+          properties:
+            type:
+              type: string
+            start_time:
+              type: number
+              format: float
+            confidence:
+              type: number
+              format: float
+          required:
+            - type
+            - start_time
+            - confidence
     AudioEventEnded:
       type: object
       properties:
         message:
           enum:
             - AudioEventEnded
-        type:
-          type: string
-        end_time:
-          type: number
-          format: float
+        event:
+          type: object
+          properties:
+            type:
+              type: string
+            end_time:
+              type: number
+              format: float
+          required:
+            - type
+            - end_time
     Info:
       type: object
       properties:


### PR DESCRIPTION
The schema was incorrect for `AudioEventStarted` and `AudioEventEnded`. This brings them in line with actual API behaviour.