### PR TITLE
Add packages for browser input audio device selection

### DIFF
--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@speechmatics/flow-client-react": "workspace:*",
+    "@speechmatics/browser-audio-input-react": "workspace:*",
     "@picocss/pico": "^2.0.6",
     "next": "15.0.1",
     "react": "19.0.0-rc-69d4b800-20241021",

--- a/examples/nextjs/src/app/flow/Component.tsx
+++ b/examples/nextjs/src/app/flow/Component.tsx
@@ -41,7 +41,10 @@ export default function Component({
   );
 
   const startSession = useCallback(
-    async (personaId: string) => {
+    async ({
+      personaId,
+      deviceId,
+    }: { personaId: string; deviceId?: string }) => {
       try {
         setLoading(true);
         const audioContext = new AudioContext({ sampleRate: SAMPLE_RATE });
@@ -57,7 +60,7 @@ export default function Component({
             sample_rate: SAMPLE_RATE,
           },
         });
-        const mediaStream = await startRecording(audioContext);
+        const mediaStream = await startRecording(audioContext, deviceId);
         setMediaStream(mediaStream);
       } finally {
         setLoading(false);

--- a/examples/nextjs/src/app/flow/Controls.tsx
+++ b/examples/nextjs/src/app/flow/Controls.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { type ChangeEvent, useState } from 'react';
 import { useFlow } from '@speechmatics/flow-client-react';
+import { useAudioDevices } from '@speechmatics/browser-audio-input-react';
 
 export function Controls({
   loading,
@@ -9,21 +10,27 @@ export function Controls({
 }: {
   loading: boolean;
   personas: Record<string, { name: string }>;
-  startSession: (personaId: string) => Promise<void>;
+  startSession: ({
+    deviceId,
+    personaId,
+  }: { deviceId?: string; personaId: string }) => Promise<void>;
   stopSession: () => Promise<void>;
 }) {
   const { socketState } = useFlow();
   const connected = socketState === 'open';
-  const [persona, setPersona] = useState(Object.keys(personas)[0]);
+  const [personaId, setPersonaId] = useState(Object.keys(personas)[0]);
+
+  const [deviceId, setDeviceId] = useState<string>();
 
   return (
     <article>
       <div className="grid">
+        <MicrophoneSelect setDeviceId={setDeviceId} />
         <label>
           Select persona
           <select
             onChange={(e) => {
-              setPersona(e.target.value);
+              setPersonaId(e.target.value);
             }}
           >
             {Object.entries(personas).map(([id, { name }]) => (
@@ -39,11 +46,68 @@ export function Controls({
           type="button"
           className={connected ? 'secondary' : undefined}
           aria-busy={loading}
-          onClick={connected ? stopSession : () => startSession(persona)}
+          onClick={
+            connected
+              ? stopSession
+              : () => startSession({ personaId, deviceId })
+          }
         >
           {connected ? 'Stop conversation' : 'Start conversation'}
         </button>
       </div>
     </article>
   );
+}
+
+function MicrophoneSelect({
+  setDeviceId,
+}: { setDeviceId: (deviceId: string) => void }) {
+  const devices = useAudioDevices();
+
+  switch (devices.permissionState) {
+    case 'prompt':
+      return (
+        <label>
+          Enable mic permissions
+          <select
+            onClick={devices.promptPermissions}
+            onKeyDown={devices.promptPermissions}
+          />
+        </label>
+      );
+    case 'prompting':
+      return (
+        <label>
+          Enable mic permissions
+          <select aria-busy="true" />
+        </label>
+      );
+    case 'granted': {
+      const onChange = (e: ChangeEvent<HTMLSelectElement>) => {
+        setDeviceId(e.target.value);
+      };
+      return (
+        <label>
+          Select audio device
+          <select onChange={onChange}>
+            {devices.deviceList.map((d) => (
+              <option key={d.deviceId} value={d.deviceId}>
+                {d.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      );
+    }
+    case 'denied':
+      return (
+        <label>
+          Microphone permission disabled
+          <select disabled />
+        </label>
+      );
+    default:
+      devices satisfies never;
+      return null;
+  }
 }

--- a/examples/nextjs/src/lib/audio-hooks.ts
+++ b/examples/nextjs/src/lib/audio-hooks.ts
@@ -12,7 +12,7 @@ export function usePcmMicrophoneAudio(onAudio: (audio: Float32Array) => void) {
   const mediaStreamRef = useRef<MediaStream>();
 
   const startRecording = useCallback(
-    async (audioContext: AudioContext) => {
+    async (audioContext: AudioContext, deviceId?: string) => {
       // If stream is present, it means we're already recording, nothing to do
       if (mediaStreamRef.current) {
         return mediaStreamRef.current;
@@ -20,6 +20,7 @@ export function usePcmMicrophoneAudio(onAudio: (audio: Float32Array) => void) {
 
       const mediaStream = await navigator.mediaDevices.getUserMedia({
         audio: {
+          deviceId,
           sampleRate: audioContext?.sampleRate,
           sampleSize: 16,
           channelCount: 1,

--- a/packages/browser-audio-input-react/README.md
+++ b/packages/browser-audio-input-react/README.md
@@ -1,0 +1,71 @@
+# Browser audio input (React)
+
+React bindings for the `@speechmatics/browser-audio-input` package, letting you manage audio input devices and permissions across browsers.
+
+## Installation
+
+```
+npm i @speechmatics/browser-audio-input-react
+```
+
+## Usage
+
+Below is an example of a Microphone selection component.
+
+```TSX
+import { useAudioDevices } from "@speechmatics/browser-audio-input-react";
+
+function MicrophoneSelect({
+  setDeviceId,
+}: { setDeviceId: (deviceId: string) => void }) {
+  const devices = useAudioDevices();
+
+  switch (devices.permissionState) {
+    case 'prompt':
+      return (
+        <label>
+          Enable mic permissions
+          <select
+            onClick={devices.promptPermissions}
+            onKeyDown={devices.promptPermissions}
+          />
+        </label>
+      );
+    case 'prompting':
+      return (
+        <label>
+          Enable mic permissions
+          <select aria-busy="true" />
+        </label>
+      );
+    case 'granted': {
+      const onChange = (e: ChangeEvent<HTMLSelectElement>) => {
+        setDeviceId(e.target.value);
+      };
+      return (
+        <label>
+          Select audio device
+          <select onChange={onChange}>
+            {devices.deviceList.map((d) => (
+              <option key={d.deviceId} value={d.deviceId}>
+                {d.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      );
+    }
+    case 'denied':
+      return (
+        <label>
+          Microphone permission disabled
+          <select disabled />
+        </label>
+      );
+    default:
+      devices satisfies never;
+      return null;
+  }
+}
+
+```

--- a/packages/browser-audio-input-react/package.json
+++ b/packages/browser-audio-input-react/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@speechmatics/browser-audio-input-react",
+  "version": "0.0.1",
+  "description": "React hooks for managing audio inputs and permissions across browsers",
+  "exports": ["./dist/index.js"],
+  "module": "./dist/index.js",
+  "typings": "./dist/index.d.ts",
+  "files": ["dist/", "README.md"],
+  "scripts": {
+    "build": "rm -rf dist/ && pnpm -C ../browser-audio-input build && pnpm rollup -c",
+    "prepare": "pnpm build",
+    "format": "biome format --write .",
+    "lint": "biome lint --write ."
+  },
+  "keywords": [
+    "Flow",
+    "API",
+    "React",
+    "hooks",
+    "transcription",
+    "speech",
+    "intelligence"
+  ],
+  "dependencies": {
+    "@speechmatics/browser-audio-input": "workspace:*"
+  },
+  "author": "",
+  "license": "MIT",
+  "peerDependencies": {
+    "react": "^18 || ^19"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "typescript-event-target": "^1.1.1"
+  }
+}

--- a/packages/browser-audio-input-react/rollup.config.mjs
+++ b/packages/browser-audio-input-react/rollup.config.mjs
@@ -1,0 +1,39 @@
+import esbuild from 'rollup-plugin-esbuild';
+import dts from 'rollup-plugin-dts';
+
+import packageJSON from './package.json' assert { type: 'json' };
+
+// Based on gist
+//https://gist.github.com/aleclarson/9900ed2a9a3119d865286b218e14d226
+
+/** @returns {import("rollup").RollupOptions[]} */
+export default function rollup() {
+  return [
+    {
+      plugins: [esbuild()],
+      input: 'src/index.ts',
+      output: [
+        {
+          file: packageJSON.module,
+          format: 'es',
+          sourcemap: true,
+          strict: false,
+        },
+      ],
+    },
+
+    {
+      plugins: [
+        dts({
+          compilerOptions: {
+            removeComments: true,
+          },
+        }),
+      ],
+      input: 'src/index.ts',
+      output: {
+        file: `${packageJSON.module.replace('.js', '')}.d.ts`,
+      },
+    },
+  ];
+}

--- a/packages/browser-audio-input-react/src/index.ts
+++ b/packages/browser-audio-input-react/src/index.ts
@@ -1,0 +1,77 @@
+import { useCallback, useSyncExternalStore } from 'react';
+import { getAudioDevicesStore } from '@speechmatics/browser-audio-input';
+
+// Here we subscribe to the device state browser event
+// When devices change, the getDevices callback is invoked
+function subscribeDevices(callback: () => void) {
+  const audioDevices = getAudioDevicesStore();
+  audioDevices.addEventListener('changeDevices', callback);
+  return () => {
+    audioDevices.removeEventListener('changeDevices', callback);
+  };
+}
+const getDevices = () => getAudioDevicesStore().devices;
+
+function useAudioDeviceList() {
+  return useSyncExternalStore(subscribeDevices, getDevices, getDevices);
+}
+
+// Here we subscribe to the user's provided permissions
+// When the permission state changes, the useAudioDevices hook is called
+function subscribePermissionState(callback: () => void) {
+  const audioDevices = getAudioDevicesStore();
+  audioDevices.addEventListener('changePermissions', callback);
+  return () => {
+    audioDevices.removeEventListener('changePermissions', callback);
+  };
+}
+const getPermissionState = () => getAudioDevicesStore().permissionState;
+function useAudioPermissionState() {
+  return useSyncExternalStore(
+    subscribePermissionState,
+    getPermissionState,
+    getPermissionState,
+  );
+}
+
+function usePromptAudioPermission() {
+  return useCallback(async () => {
+    await getAudioDevicesStore().promptPermissions();
+  }, []);
+}
+
+export type AudioDevices =
+  | { permissionState: 'prompt'; promptPermissions: () => void }
+  | { permissionState: 'prompting' }
+  | {
+      permissionState: 'granted';
+      deviceList: ReadonlyArray<MediaDeviceInfo>;
+    }
+  | { permissionState: 'denied' };
+
+export function useAudioDevices(): AudioDevices {
+  const permissionState = useAudioPermissionState();
+  const promptPermissions = usePromptAudioPermission();
+  const deviceList = useAudioDeviceList();
+
+  switch (permissionState) {
+    case 'prompt':
+      return {
+        permissionState,
+        promptPermissions,
+      };
+    case 'granted':
+      return {
+        permissionState,
+        deviceList,
+      };
+    case 'prompting':
+    case 'denied':
+      return {
+        permissionState,
+      };
+    default:
+      permissionState satisfies never;
+      throw new Error(`Unexpected permission state: ${permissionState}`);
+  }
+}

--- a/packages/browser-audio-input-react/tsconfig.json
+++ b/packages/browser-audio-input-react/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/browser-audio-input/package.json
+++ b/packages/browser-audio-input/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@speechmatics/browser-audio-input",
+  "version": "0.0.1",
+  "description": "Manage audio input devices and persmissions across browsers",
+  "exports": ["./dist/index.js"],
+  "module": "./dist/index.js",
+  "type": "module",
+  "files": ["dist/", "README.md"],
+  "scripts": {
+    "build": "rollup -c",
+    "prepare": "pnpm build",
+    "format": "biome format --write .",
+    "lint": "biome lint --write ."
+  },
+  "keywords": ["Audio", "Browser", "device", "selection"],
+  "license": "MIT",
+  "dependencies": {
+    "typescript-event-target": "^1.1.1"
+  }
+}

--- a/packages/browser-audio-input/rollup.config.mjs
+++ b/packages/browser-audio-input/rollup.config.mjs
@@ -1,0 +1,54 @@
+import esbuild from 'rollup-plugin-esbuild';
+import dts from 'rollup-plugin-dts';
+
+import packageJSON from './package.json' assert { type: 'json' };
+
+// Based on gist
+//https://gist.github.com/aleclarson/9900ed2a9a3119d865286b218e14d226
+
+/** @returns {import("rollup").RollupOptions[]} */
+export default function rollup() {
+  const esm = {
+    plugins: [esbuild()],
+    input: 'src/index.ts',
+    output: {
+      file: packageJSON.module,
+      format: 'es',
+      strict: false,
+    },
+  };
+
+  const minified = {
+    plugins: [
+      esbuild({
+        minify: true,
+        optimizeDeps: {
+          include: ['typescript-event-target'],
+        },
+      }),
+    ],
+    input: 'src/index.ts',
+    output: {
+      file: packageJSON.module.replace(/\.js$/, '.min.js'),
+      name: 'BrowserAudioInput',
+      format: 'umd',
+      strict: false,
+    },
+  };
+
+  const typeDefinitions = {
+    plugins: [
+      dts({
+        compilerOptions: {
+          removeComments: true,
+        },
+      }),
+    ],
+    input: 'src/index.ts',
+    output: {
+      file: packageJSON.module.replace(/\.js$/, '.d.ts'),
+    },
+  };
+
+  return [esm, minified, typeDefinitions];
+}

--- a/packages/browser-audio-input/src/index.ts
+++ b/packages/browser-audio-input/src/index.ts
@@ -1,0 +1,95 @@
+import { TypedEventTarget } from 'typescript-event-target';
+
+interface AudioInputDevicesEventMap {
+  changeDevices: Event;
+  changePermissions: Event;
+}
+export class AudioInputDevicesStore extends TypedEventTarget<AudioInputDevicesEventMap> {
+  private _permissionState: PermissionState | 'prompting' = 'prompt';
+  private _devices: MediaDeviceInfo[] = [];
+
+  get permissionState() {
+    return this._permissionState;
+  }
+
+  set permissionState(value: PermissionState | 'prompting') {
+    this._permissionState = value;
+    this.dispatchTypedEvent(
+      'changePermissions',
+      new Event('changePermissions'),
+    );
+  }
+
+  get devices() {
+    return this._devices;
+  }
+  set devices(devices) {
+    if (devices !== this._devices) {
+      this._devices = devices;
+      this.dispatchTypedEvent('changeDevices', new Event('changeDevices'));
+    }
+  }
+
+  constructor() {
+    super();
+    if (typeof window === 'undefined') return;
+
+    this.updateDeviceList();
+    navigator.mediaDevices.addEventListener('devicechange', () => {
+      this.updateDeviceList();
+    });
+
+    // Link permissions API
+    navigator.permissions
+      // @ts-ignore: "microphone" isn't a supported PermissionName for all browsers
+      .query({ name: 'microphone' })
+      .then((permissionStatus) => {
+        this.permissionState = permissionStatus.state;
+        permissionStatus.addEventListener('change', () => {
+          this.permissionState = permissionStatus.state;
+        });
+      })
+      .catch((e) => {
+        console.warn('browser does not support microphone permissions query');
+      });
+
+    // Whenever permissions are granted, update device list
+    this.addEventListener('changePermissions', () => {
+      if (this.permissionState === 'granted') {
+        this.updateDeviceList();
+      }
+    });
+  }
+
+  async promptPermissions() {
+    if (this.permissionState === 'prompt') {
+      this.permissionState = 'prompting';
+      try {
+        const mediaStream = await navigator.mediaDevices.getUserMedia({
+          audio: true,
+          video: false,
+        });
+        if (mediaStream) {
+          this.permissionState = 'granted';
+        }
+      } catch (e) {
+        this.permissionState = 'denied';
+      }
+    }
+  }
+
+  // updateDeviceList is used to handle device enumeration once permissions have been given
+  private updateDeviceList = async () => {
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    const filtered = devices.filter((device) => {
+      return device.kind === 'audioinput' && device.deviceId !== '';
+    });
+    this.devices = filtered;
+  };
+}
+
+let audioDevicesStore: AudioInputDevicesStore | null = null;
+export function getAudioDevicesStore() {
+  audioDevicesStore ??= new AudioInputDevicesStore();
+  return audioDevicesStore;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@picocss/pico':
         specifier: ^2.0.6
         version: 2.0.6
+      '@speechmatics/browser-audio-input-react':
+        specifier: workspace:*
+        version: link:../../packages/browser-audio-input-react
       '@speechmatics/flow-client-react':
         specifier: workspace:*
         version: link:../../packages/flow-client-react
@@ -91,6 +94,28 @@ importers:
       zod:
         specifier: ^3.23.8
         version: 3.23.8
+
+  packages/browser-audio-input:
+    dependencies:
+      typescript-event-target:
+        specifier: ^1.1.1
+        version: 1.1.1
+
+  packages/browser-audio-input-react:
+    dependencies:
+      '@speechmatics/browser-audio-input':
+        specifier: workspace:*
+        version: link:../browser-audio-input
+      react:
+        specifier: ^18 || ^19
+        version: 18.3.1
+    devDependencies:
+      '@types/react':
+        specifier: ^18.3.12
+        version: 18.3.12
+      typescript-event-target:
+        specifier: ^1.1.1
+        version: 1.1.1
 
   packages/flow-client:
     dependencies:


### PR DESCRIPTION
Add two new packages based on the microphone selection flow implemented in the portal

- `@speechmatics/browser-audio-input`:
  - Contains just the store/singleton class managing audio devices.
  - Also provides a minified build in case someone wants to use this in an inline script tag
- `@speechmatics/browser-audio-input-react`:
  - React bindings for the above package
  - Constrain the types of the main exported hook
- Updated the NextJS example to use the react package

**Note**: Both these packages export only ESM (apart from the raw client which also provides a minified build). My thinking was there are practically 0 CommonJS use cases for browser microphone selection, so I omitted it from the build.