### PR TITLE
fix(real-time-client): allow user to override audio_format on start

### DIFF
--- a/packages/real-time-client/src/client.ts
+++ b/packages/real-time-client/src/client.ts
@@ -178,8 +178,8 @@ export class RealtimeClient extends TypedEventTarget<RealtimeClientEventMap> {
         });
 
         const startRecognitionMessage = {
-          ...config,
           audio_format: defaultAudioFormat,
+          ...config,
           message: 'StartRecognition' as const,
         };
 


### PR DESCRIPTION
Currently impossible to override config to audio format on the real time client. This allows the user to override