### PR TITLE
`browser-audio-input-react`: Ensure module is loaded as ESM

### DIFF
--- a/packages/browser-audio-input-react/package.json
+++ b/packages/browser-audio-input-react/package.json
@@ -2,6 +2,7 @@
   "name": "@speechmatics/browser-audio-input-react",
   "version": "0.1.0",
   "description": "React hooks for managing audio inputs and permissions across browsers",
+  "type": "module",
   "exports": ["./dist/index.js"],
   "module": "./dist/index.js",
   "typings": "./dist/index.d.ts",

--- a/packages/browser-audio-input-react/package.json
+++ b/packages/browser-audio-input-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechmatics/browser-audio-input-react",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "React hooks for managing audio inputs and permissions across browsers",
   "type": "module",
   "exports": ["./dist/index.js"],


### PR DESCRIPTION
Set `"type": "module"` for `@speechmatics/browser-audio-input-react`