### PR TITLE
Add analyser to PCM audio recorder

### DIFF
--- a/examples/nextjs/src/app/flow/Controls.tsx
+++ b/examples/nextjs/src/app/flow/Controls.tsx
@@ -9,11 +9,11 @@ import { MicrophoneSelect } from '@/lib/components/MicrophoneSelect';
 import { PersonaSelect } from './PersonaSelect';
 import { getJWT } from '../actions';
 import {
-  usePcmAudioListener,
-  usePcmAudioRecorder,
+  usePCMAudioListener,
+  usePCMAudioRecorder,
 } from '@speechmatics/browser-audio-input-react';
 import { RECORDING_SAMPLE_RATE } from '@/lib/constants';
-import { usePlayPcm16Audio } from '@/lib/audio-hooks';
+import { usePlayPCM16Audio } from '@/lib/audio-hooks';
 
 export function Controls({
   personas,
@@ -73,12 +73,12 @@ export function Controls({
 // Hook to set up two way audio between the browser and Flow
 function useFlowWithBrowserAudio() {
   const { startConversation, endConversation, sendAudio } = useFlow();
-  const { startRecording, stopRecording } = usePcmAudioRecorder();
+  const { startRecording, stopRecording } = usePCMAudioRecorder();
   const [audioContext, setAudioContext] = useState<AudioContext>();
-  const playAudio = usePlayPcm16Audio(audioContext);
+  const playAudio = usePlayPCM16Audio(audioContext);
 
   // Send audio to Flow when we receive it from the active input device
-  usePcmAudioListener(sendAudio);
+  usePCMAudioListener(sendAudio);
 
   // Play back audio when we receive it from flow
   useFlowEventListener(
@@ -115,7 +115,7 @@ function useFlowWithBrowserAudio() {
       });
       setAudioContext(audioContext);
 
-      await startRecording({ deviceId, sampleRate: RECORDING_SAMPLE_RATE });
+      await startRecording({ deviceId, audioContext });
     },
     [startConversation, startRecording],
   );

--- a/examples/nextjs/src/app/flow/Status.tsx
+++ b/examples/nextjs/src/app/flow/Status.tsx
@@ -1,10 +1,10 @@
 'use client';
-import { usePcmAudioRecorder } from '@speechmatics/browser-audio-input-react';
+import { usePCMAudioRecorder } from '@speechmatics/browser-audio-input-react';
 import { useFlow } from '@speechmatics/flow-client-react';
 
 export function Status() {
   const { socketState, sessionId } = useFlow();
-  const { isRecording } = usePcmAudioRecorder();
+  const { isRecording } = usePCMAudioRecorder();
 
   return (
     <article>

--- a/examples/nextjs/src/app/flow/page.tsx
+++ b/examples/nextjs/src/app/flow/page.tsx
@@ -1,5 +1,5 @@
 import { fetchPersonas, FlowProvider } from '@speechmatics/flow-client-react';
-import { PcmAudioRecorderProvider } from '@speechmatics/browser-audio-input-react';
+import { PCMAudioRecorderProvider } from '@speechmatics/browser-audio-input-react';
 import { Controls } from './Controls';
 import { Status } from './Status';
 import { OutputView } from './OutputView';
@@ -17,7 +17,7 @@ export default async function Home() {
     // Two context providers:
     // 1. For the audio recorder (see https://github.com/speechmatics/speechmatics-js-sdk/blob/main/packages/browser-audio-input-react/README.md)
     // 2. For the Flow API client (see https://github.com/speechmatics/speechmatics-js-sdk/blob/main/packages/flow-client-react/README.md)
-    <PcmAudioRecorderProvider workletScriptURL="/js/pcm-audio-worklet.min.js">
+    <PCMAudioRecorderProvider workletScriptURL="/js/pcm-audio-worklet.min.js">
       <FlowProvider appId="nextjs-example" audioBufferingMs={500}>
         <section>
           <h3>Flow Example</h3>
@@ -30,6 +30,6 @@ export default async function Home() {
           </section>
         </section>
       </FlowProvider>
-    </PcmAudioRecorderProvider>
+    </PCMAudioRecorderProvider>
   );
 }

--- a/examples/nextjs/src/app/real-time/Controls.tsx
+++ b/examples/nextjs/src/app/real-time/Controls.tsx
@@ -1,8 +1,8 @@
 'use client';
 import { type FormEvent, useCallback, useEffect } from 'react';
 import {
-  usePcmAudioListener,
-  usePcmAudioRecorder,
+  usePCMAudioListener,
+  usePCMAudioRecorder,
 } from '@speechmatics/browser-audio-input-react';
 import {
   type RealtimeTranscriptionConfig,
@@ -20,9 +20,9 @@ export function Controls({
   const { startTranscription, stopTranscription, sendAudio } =
     useRealtimeTranscription();
 
-  const { isRecording, startRecording, stopRecording } = usePcmAudioRecorder();
+  const { isRecording, startRecording, stopRecording } = usePCMAudioRecorder();
 
-  usePcmAudioListener(sendAudio);
+  usePCMAudioListener(sendAudio);
 
   const startSession = useCallback(
     async ({
@@ -31,7 +31,10 @@ export function Controls({
     }: RealtimeTranscriptionConfig & { deviceId?: string }) => {
       const jwt = await getJWT('rt');
       await startTranscription(jwt, config);
-      await startRecording({ deviceId, sampleRate: RECORDING_SAMPLE_RATE });
+      const audioContext = new AudioContext({
+        sampleRate: RECORDING_SAMPLE_RATE,
+      });
+      await startRecording({ deviceId, audioContext });
     },
     [startTranscription, startRecording],
   );
@@ -76,7 +79,7 @@ export function Controls({
 }
 
 function StartStopButton() {
-  const { stopRecording } = usePcmAudioRecorder();
+  const { stopRecording } = usePCMAudioRecorder();
   const { stopTranscription } = useRealtimeTranscription();
 
   const stopSession = useCallback(() => {

--- a/examples/nextjs/src/app/real-time/Output.tsx
+++ b/examples/nextjs/src/app/real-time/Output.tsx
@@ -6,6 +6,8 @@ import {
 } from '@speechmatics/real-time-client-react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { ErrorFallback } from '@/lib/components/ErrorFallback';
+import { AudioVisualizer } from '@/lib/components/AudioVisualizer';
+import { usePCMAudioRecorder } from '@speechmatics/browser-audio-input-react';
 
 export function Output() {
   return (
@@ -19,10 +21,12 @@ export function Component() {
   const [transcription, dispatch] = useReducer(transcriptReducer, []);
 
   useRealtimeEventListener('receiveMessage', (e) => dispatch(e.data));
+  const { analyser } = usePCMAudioRecorder();
 
   return (
     <article>
       <header>Output</header>
+      <AudioVisualizer analyser={analyser} />
       <p>
         {transcription.map(({ text, startTime, endTime, punctuation }) => (
           <span key={`${text}-${startTime}-${endTime}`}>

--- a/examples/nextjs/src/app/real-time/Output.tsx
+++ b/examples/nextjs/src/app/real-time/Output.tsx
@@ -25,8 +25,10 @@ export function Component() {
 
   return (
     <article>
-      <header>Output</header>
-      <AudioVisualizer analyser={analyser} />
+      <header>
+        Output &nbsp;&nbsp;
+        <AudioVisualizer analyser={analyser} />
+      </header>
       <p>
         {transcription.map(({ text, startTime, endTime, punctuation }) => (
           <span key={`${text}-${startTime}-${endTime}`}>

--- a/examples/nextjs/src/app/real-time/Status.tsx
+++ b/examples/nextjs/src/app/real-time/Status.tsx
@@ -1,10 +1,10 @@
 'use client';
-import { usePcmAudioRecorder } from '@speechmatics/browser-audio-input-react';
+import { usePCMAudioRecorder } from '@speechmatics/browser-audio-input-react';
 import { useRealtimeTranscription } from '@speechmatics/real-time-client-react';
 
 export function Status() {
   const { socketState, sessionId } = useRealtimeTranscription();
-  const { isRecording } = usePcmAudioRecorder();
+  const { isRecording } = usePCMAudioRecorder();
 
   return (
     <article>

--- a/examples/nextjs/src/app/real-time/page.tsx
+++ b/examples/nextjs/src/app/real-time/page.tsx
@@ -2,7 +2,7 @@ import {
   getFeatures,
   RealtimeTranscriptionProvider,
 } from '@speechmatics/real-time-client-react';
-import { PcmAudioRecorderProvider } from '@speechmatics/browser-audio-input-react';
+import { PCMAudioRecorderProvider } from '@speechmatics/browser-audio-input-react';
 import { Controls } from './Controls';
 import { Status } from './Status';
 import { Output } from './Output';
@@ -21,7 +21,7 @@ export default async function Page() {
   );
 
   return (
-    <PcmAudioRecorderProvider workletScriptURL="/js/pcm-audio-worklet.min.js">
+    <PCMAudioRecorderProvider workletScriptURL="/js/pcm-audio-worklet.min.js">
       <RealtimeTranscriptionProvider appId="nextjs-rt-example">
         <section>
           <h3>Real-time Example</h3>
@@ -34,6 +34,6 @@ export default async function Page() {
           </section>
         </section>
       </RealtimeTranscriptionProvider>
-    </PcmAudioRecorderProvider>
+    </PCMAudioRecorderProvider>
   );
 }

--- a/examples/nextjs/src/lib/audio-hooks.ts
+++ b/examples/nextjs/src/lib/audio-hooks.ts
@@ -1,6 +1,6 @@
 import { useRef, useCallback, useEffect } from 'react';
 
-export function usePlayPcm16Audio(audioContext: AudioContext | undefined) {
+export function usePlayPCM16Audio(audioContext: AudioContext | undefined) {
   const playbackStartTime = useRef(0);
 
   useEffect(() => {

--- a/examples/nextjs/src/lib/components/AudioVisualizer.tsx
+++ b/examples/nextjs/src/lib/components/AudioVisualizer.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useRef } from 'react';
+
+const BAR_COUNT = 8;
+const BAR_HEIGHT = 32;
+
+export function AudioVisualizer({ analyser }: { analyser?: AnalyserNode }) {
+  const svgRef = useRef<SVGSVGElement>(null);
+
+  useEffect(() => {
+    if (!analyser) return;
+
+    let frameId: ReturnType<typeof requestAnimationFrame> | undefined =
+      undefined;
+    function report() {
+      if (!analyser) return;
+
+      const binCount = analyser.frequencyBinCount;
+      const data = new Uint8Array(binCount);
+
+      analyser.getByteFrequencyData(data);
+
+      const clippedData = data.slice(0, data.length / 2);
+
+      const stepSize = Math.floor(clippedData.length / BAR_COUNT);
+      const lineElements = svgRef.current?.querySelectorAll('line');
+
+      for (let i = 0; i < BAR_COUNT; i++) {
+        const barAmp =
+          (BAR_HEIGHT *
+            (data
+              .slice(i * stepSize, (i + 1) * stepSize)
+              .reduce((acc, curr) => acc + curr, 0) /
+              stepSize)) /
+          255;
+
+        lineElements?.[i].setAttribute('y1', `${BAR_HEIGHT - barAmp}`);
+        lineElements?.[i].setAttribute('y2', `${BAR_HEIGHT + barAmp}`);
+      }
+      frameId = requestAnimationFrame(report);
+    }
+
+    report();
+
+    return () => {
+      if (typeof frameId === 'number') {
+        cancelAnimationFrame(frameId);
+      }
+    };
+  }, [analyser]);
+
+  if (!analyser) return null;
+
+  return (
+    <svg
+      ref={svgRef}
+      xmlns="http://www.w3.org/2000/svg"
+      width="32px"
+      height="32px"
+      viewBox="0 0 64 64"
+      fill="none"
+    >
+      <title>Audio</title>
+      {new Array(BAR_COUNT).fill(null).map((_, n) => (
+        <line
+          // biome-ignore lint/suspicious/noArrayIndexKey: static
+          key={n}
+          x1={8 * n + 4}
+          x2={8 * n + 4}
+          y1={BAR_HEIGHT}
+          y2={BAR_HEIGHT}
+          stroke="#000"
+          strokeOpacity="1"
+          strokeWidth="4"
+          strokeLinecap="round"
+        />
+      ))}
+    </svg>
+  );
+}

--- a/packages/browser-audio-input-react/README.md
+++ b/packages/browser-audio-input-react/README.md
@@ -91,9 +91,9 @@ function App() {
 
 function Component() {
   const { startRecording, stopRecording, mediaStream, isRecording } =
-    usePcmAudioRecorder();
+    usePCMAudioRecorder();
 
-  usePcmAudioListener((audio) => {
+  usePCMAudioListener((audio) => {
     // Handle Float32Array of audio however you like
   });
 }

--- a/packages/browser-audio-input-react/README.md
+++ b/packages/browser-audio-input-react/README.md
@@ -74,7 +74,7 @@ function MicrophoneSelect({
 
 ### PCM recording
 
-This package exposes a context provider that can be used like so:
+This package exposes a context provider that can be used to share a **single PCM recorder across the app**. This is quite handy, as you can control and the recorder from any component in your app!
 
 ```TSX
 import { PcmAudioRecorderProvider } from '@speechmatics/browser-audio-input-react';

--- a/packages/browser-audio-input-react/README.md
+++ b/packages/browser-audio-input-react/README.md
@@ -183,3 +183,16 @@ function App() {
   );
 }
 ```
+
+### Creating audio visualizers
+
+The hook `usePCMAudioRecorder` provides an `analyser` object, which is an instance of [`AnalyserNode`](https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode).
+
+```typescript
+const { analyser } = usePCMAudioRecorder();
+
+```
+
+MDN has a [great guide on audio visualizers for the WebAudio API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Visualizations_with_Web_Audio_API). The basic idea though is that you can use `requestAnimationFrame` to repeatedly read the [`analyser.getFloatFrequencyData`](https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode/getFloatFrequencyData) method to animate whatever DOM elements you like.
+
+See the [`AudioVisualizer`](../../examples/nextjs/src/lib/components/AudioVisualizer.tsx) in the NextJS demo app for a complete example.

--- a/packages/browser-audio-input-react/package.json
+++ b/packages/browser-audio-input-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechmatics/browser-audio-input-react",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "React hooks for managing audio inputs and permissions across browsers",
   "type": "module",
   "exports": ["./dist/index.js"],

--- a/packages/browser-audio-input-react/package.json
+++ b/packages/browser-audio-input-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechmatics/browser-audio-input-react",
-  "version": "1.0.0",
+  "version": "1.0.1-rc0",
   "description": "React hooks for managing audio inputs and permissions across browsers",
   "type": "module",
   "exports": ["./dist/index.js"],

--- a/packages/browser-audio-input-react/package.json
+++ b/packages/browser-audio-input-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechmatics/browser-audio-input-react",
-  "version": "1.0.1-rc0",
+  "version": "1.0.1",
   "description": "React hooks for managing audio inputs and permissions across browsers",
   "type": "module",
   "exports": ["./dist/index.js"],

--- a/packages/browser-audio-input/README.md
+++ b/packages/browser-audio-input/README.md
@@ -23,16 +23,16 @@ We will add non-React examples soon. If you'd like to request a specific one, fe
 ```typescript
 import {
   type InputAudioEvent,
-  PcmRecorder,
+  PCMRecorder,
 } from '@speechmatics/browser-audio-input';
 
-const pcmRecorder = new PcmRecorder("/path/to/pcm-audio-worklet.min.js"); // <- (see note below about this)
+const PCMRecorder = new PCMRecorder("/path/to/pcm-audio-worklet.min.js"); // <- (see note below about this)
 
-pcmRecorder.addEventListener('recordingStarted', () => {
+PCMRecorder.addEventListener('recordingStarted', () => {
   console.log("Recording started!");
 });
 
-pcmRecorder.startRecording()
+PCMRecorder.startRecording()
 
 ```
 
@@ -86,9 +86,9 @@ Vite supports referencing bundled code by URL for use in Workers. This can be us
 ```typescript
 import {
   type InputAudioEvent,
-  PcmRecorder,
+  PCMRecorder,
 } from '@speechmatics/browser-audio-input';
-import pcmAudioWorkletUrl from "@speechmatics/browser-audio-input/pcm-audio-worklet.min.js?url";
+import PCMAudioWorkletUrl from "@speechmatics/browser-audio-input/pcm-audio-worklet.min.js?url";
 
-const pcmRecorder = new PcmRecorder(pcmAudioWorkletUrl);
+const PCMRecorder = new PCMRecorder(PCMAudioWorkletUrl);
 ```

--- a/packages/browser-audio-input/package.json
+++ b/packages/browser-audio-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechmatics/browser-audio-input",
-  "version": "1.0.1-rc0",
+  "version": "1.0.1",
   "description": "Manage audio input devices and persmissions across browsers",
   "exports": {
     ".": "./dist/index.js",

--- a/packages/browser-audio-input/package.json
+++ b/packages/browser-audio-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechmatics/browser-audio-input",
-  "version": "0.1.0",
+  "version": "1.0.0-rc0",
   "description": "Manage audio input devices and persmissions across browsers",
   "exports": {
     ".": "./dist/index.js",

--- a/packages/browser-audio-input/package.json
+++ b/packages/browser-audio-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechmatics/browser-audio-input",
-  "version": "1.0.0-rc0",
+  "version": "1.0.1-rc0",
   "description": "Manage audio input devices and persmissions across browsers",
   "exports": {
     ".": "./dist/index.js",

--- a/packages/browser-audio-input/src/pcm-recorder.ts
+++ b/packages/browser-audio-input/src/pcm-recorder.ts
@@ -108,10 +108,3 @@ export class AudioModuleRegistrationError extends Error {
     this.name = 'AudioModuleRegistrationError';
   }
 }
-
-export class AnalyserCreationError extends Error {
-  constructor(message: string) {
-    super(`Failed to create analyser: ${message}`);
-    this.name = 'AnalyserCreationError';
-  }
-}

--- a/packages/browser-audio-input/src/pcm-recorder.ts
+++ b/packages/browser-audio-input/src/pcm-recorder.ts
@@ -1,54 +1,50 @@
 import { TypedEventTarget } from 'typescript-event-target';
 
+const RECORDING_STARTED = 'recordingStarted';
+const RECORDING_STOPPED = 'recordingStopped';
+const AUDIO = 'audio';
+
 export class InputAudioEvent extends Event {
   constructor(public readonly data: Float32Array) {
-    super('audio');
+    super(AUDIO);
   }
 }
 
-interface PcmRecorderEventMap {
-  recordingStarted: Event;
-  recordingStopped: Event;
-  audio: InputAudioEvent;
+interface PCMRecorderEventMap {
+  [RECORDING_STARTED]: Event;
+  [RECORDING_STOPPED]: Event;
+  [AUDIO]: InputAudioEvent;
 }
 
 export type StartRecordingOptions = {
   deviceId?: string;
   recordingOptions?: MediaTrackConstraints;
-} & ({ audioContext: AudioContext } | { sampleRate: number });
+  audioContext: AudioContext;
+};
 
-export class PcmRecorder extends TypedEventTarget<PcmRecorderEventMap> {
+export class PCMRecorder extends TypedEventTarget<PCMRecorderEventMap> {
   constructor(readonly workletScriptURL: string) {
     super();
   }
 
-  private _mediaStream: MediaStream | undefined;
-  public get mediaStream() {
-    return this._mediaStream;
+  private mediaStream: MediaStream | undefined;
+  private audioContext: AudioContext | undefined = undefined;
+  private inputSourceNode: MediaStreamAudioSourceNode | undefined = undefined;
+  private _analyser: AnalyserNode | undefined = undefined;
+
+  get analyser() {
+    return this._analyser;
   }
 
-  private selfManagedAudioContext: AudioContext | undefined = undefined;
-
   get isRecording() {
-    return this._mediaStream?.active ?? false;
+    return this.mediaStream?.active ?? false;
   }
 
   async startRecording(options: StartRecordingOptions) {
-    let audioContext: AudioContext;
-
-    if ('audioContext' in options) {
-      audioContext = options.audioContext;
-    } else {
-      try {
-        audioContext = new AudioContext({ sampleRate: options.sampleRate });
-        this.selfManagedAudioContext = audioContext;
-      } catch (err) {
-        throw new AudioContextCreationError(err);
-      }
-    }
+    this.audioContext = options.audioContext;
 
     try {
-      await audioContext.audioWorklet.addModule(this.workletScriptURL);
+      await this.audioContext.audioWorklet.addModule(this.workletScriptURL);
     } catch (err) {
       throw new AudioModuleRegistrationError(this.workletScriptURL, err);
     }
@@ -60,41 +56,48 @@ export class PcmRecorder extends TypedEventTarget<PcmRecorderEventMap> {
       ...(options.recordingOptions ?? {}),
     };
 
-    this._mediaStream = await navigator.mediaDevices.getUserMedia({
+    this.mediaStream = await navigator.mediaDevices.getUserMedia({
       audio: {
         deviceId: options.deviceId,
         ...constraints,
       },
     });
 
-    const input = audioContext.createMediaStreamSource(this._mediaStream);
-    const processor = new AudioWorkletNode(audioContext, 'pcm-audio-processor');
+    this.inputSourceNode = this.audioContext.createMediaStreamSource(
+      this.mediaStream,
+    );
+    const processor = new AudioWorkletNode(
+      this.audioContext,
+      'pcm-audio-processor',
+    );
 
     processor.port.onmessage = (event) => {
       const inputBuffer = event.data;
-      this.dispatchTypedEvent('audio', new InputAudioEvent(inputBuffer));
+      this.dispatchTypedEvent(AUDIO, new InputAudioEvent(inputBuffer));
     };
 
-    input.connect(processor);
-    processor.connect(audioContext.destination);
+    this.inputSourceNode.connect(processor);
+    processor.connect(this.audioContext.destination);
 
-    this.dispatchTypedEvent('recordingStarted', new Event('recordingStarted'));
+    this._analyser = this.audioContext.createAnalyser();
+    this.inputSourceNode.connect(this._analyser);
+
+    this.dispatchTypedEvent(RECORDING_STARTED, new Event(RECORDING_STARTED));
   }
 
   stopRecording() {
-    if (this._mediaStream) {
-      for (const track of this._mediaStream.getTracks()) {
+    if (this.mediaStream) {
+      for (const track of this.mediaStream.getTracks()) {
         track.stop();
       }
-      this._mediaStream = undefined;
+      this.inputSourceNode?.disconnect();
 
-      this.selfManagedAudioContext?.close();
-      this.selfManagedAudioContext = undefined;
+      this.mediaStream = undefined;
+      this.inputSourceNode = undefined;
+      this._analyser = undefined;
+      this.audioContext = undefined;
 
-      this.dispatchTypedEvent(
-        'recordingStopped',
-        new Event('recordingStopped'),
-      );
+      this.dispatchTypedEvent(RECORDING_STOPPED, new Event(RECORDING_STOPPED));
     }
   }
 }
@@ -106,9 +109,9 @@ export class AudioModuleRegistrationError extends Error {
   }
 }
 
-export class AudioContextCreationError extends Error {
-  constructor(error: unknown) {
-    super('Failed to create audio context', { cause: error });
-    this.name = 'AudioContextCreationError';
+export class AnalyserCreationError extends Error {
+  constructor(message: string) {
+    super(`Failed to create analyser: ${message}`);
+    this.name = 'AnalyserCreationError';
   }
 }

--- a/packages/real-time-client-react/README.md
+++ b/packages/real-time-client-react/README.md
@@ -48,8 +48,8 @@ Below is an example of usage in the browser.
     } from '@speechmatics/real-time-client-react';
     
     import {
-      usePcmAudioListener,
-      usePcmAudioRecorder,
+      usePCMAudioListener,
+      usePCMAudioRecorder,
     } from '@speechmatics/browser-audio-input-react';
 
     // We recommend 16_000Hz sample rate for speech audio.
@@ -60,10 +60,10 @@ Below is an example of usage in the browser.
       const { startTranscription, stopTranscription, sendAudio, socketState } =
         useRealtimeTranscription();
 
-      const { isRecording, startRecording, stopRecording } = usePcmAudioRecorder();
+      const { isRecording, startRecording, stopRecording } = usePCMAudioRecorder();
 
       // Send audio to Speechmatics when captured
-      usePcmAudioListener(sendAudio);
+      usePCMAudioListener(sendAudio);
 
       const startSession = useCallback(
         async (config: RealtimeTranscriptionConfig) => {


### PR DESCRIPTION
# Problem

Creating a visualizer for the audio recorded with `@speechmatics/browser-audio-input-react` is too hard.

# Solution

This PR updates the packages `@speechmatics/browser-audio-input` and `@speechmatics/browser-audio-input-react` to make it easier for consumers to create audio visualizers based on the recorded audio.

**This is a breaking change**. Major versions for both packages have been bumped.

- Get rid of the `selfManagedAudioContext`. Consumers **must** now pass an `AudioContext` to the `startRecording` function. This is because it's [best to share one `AudioContext` instance per page, according to MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/AudioContext#:~:text=It%27s%20recommended%20to%20create%20one%20AudioContext%20and%20reuse%20it%20instead%20of%20initializing%20a%20new%20one%20each%20time%2C)
- Remove `mediaStream` property from the `PCMRecorder` class, as it doesn't serve much purpose outside the class
- Create and expose an `AnalyserNode` directly from the `PCMRecorder` class
- Update `browser-audio-input-react` package to expose the analyser to the top level hook
- Style change: Rename `Pcm*` to `PCM*` for all user-facing APIs, since it is an acronym