### PR TITLE
Real-time: Extend socket state events with current status

### DIFF
--- a/packages/real-time-client-react/package.json
+++ b/packages/real-time-client-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechmatics/real-time-client-react",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "React hooks for interacting with the Speechmatics Real-Time API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/real-time-client/README.md
+++ b/packages/real-time-client/README.md
@@ -1,10 +1,7 @@
 
 # Speechmatics real-time client 🎤
 
-> [!WARNING]
-> This package is still in beta. It should be as functional as the legacy package, but some behaviour may have changed.
-
-Official JS client for the Speechmatics batch jobs API.
+Official JS client for the Speechmatics real-time transcription API.
 
 API documentation can be found here: https://docs.speechmatics.com/rt-api-ref
 
@@ -18,8 +15,6 @@ npm i @speechmatics/real-time-client
 > For React Native, make sure to install the [`event-target-polyfill`](https://www.npmjs.com/package/event-target-polyfill) package, or any other polyfill for the [`EventTarget` class](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget)
 
 ## Usage
-
-
 
 More examples will be available soon. For now, you can checkout the [NodeJS example](/examples/nodejs/real-time-file-example.ts).
 

--- a/packages/real-time-client/package.json
+++ b/packages/real-time-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechmatics/real-time-client",
-  "version": "5.0.7",
+  "version": "5.0.8",
   "description": "Client for the Speechmatics real-time API",
   "main": "dist/index.js",
   "browser": "dist/index.browser.js",

--- a/packages/real-time-client/src/client.ts
+++ b/packages/real-time-client/src/client.ts
@@ -38,17 +38,16 @@ export type RealtimeServerMessage =
   | Warning
   | ModelError;
 
-export type ConnectionState =
-  | 'idle'
-  | 'connecting'
-  | 'starting'
-  | 'running'
-  | 'stopping';
+export class SocketStateChangeEvent extends Event {
+  constructor(public readonly socketState: RealtimeClient['socketState']) {
+    super('socketStateChange');
+  }
+}
 
 export interface RealtimeClientEventMap {
   sendMessage: MessageEvent<RealtimeClientMessage>;
   receiveMessage: MessageEvent<RealtimeServerMessage>;
-  socketStateChange: Event;
+  socketStateChange: SocketStateChangeEvent;
 }
 
 export interface RealtimeClientOptions {
@@ -116,7 +115,7 @@ export class RealtimeClient extends TypedEventTarget<RealtimeClientEventMap> {
       this.socket = new WebSocket(url.toString());
       this.dispatchTypedEvent(
         'socketStateChange',
-        new Event('socketStateChange'),
+        new SocketStateChangeEvent(this.socketState),
       );
 
       this.socket.addEventListener(
@@ -130,7 +129,7 @@ export class RealtimeClient extends TypedEventTarget<RealtimeClientEventMap> {
       this.socket.addEventListener('error', (error) => {
         this.dispatchTypedEvent(
           'socketStateChange',
-          new Event('socketStateChange'),
+          new SocketStateChangeEvent(this.socketState),
         );
         // In case the above hasn't resolved, we can reject here rather than waiting
         // If the above has resolved, this will be ignored
@@ -140,7 +139,7 @@ export class RealtimeClient extends TypedEventTarget<RealtimeClientEventMap> {
       this.socket.addEventListener('close', () => {
         this.dispatchTypedEvent(
           'socketStateChange',
-          new Event('socketStateChange'),
+          new SocketStateChangeEvent(this.socketState),
         );
       });
 


### PR DESCRIPTION
- Add `SocketStateChangeEvent` which can be used for hooking into socket state changes
- Remove unused `ConnectionState` type