### PR TITLE
RT: Add option to disable timeout on `stopRecognition()`

### DIFF
--- a/examples/nodejs/package.json
+++ b/examples/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs-example",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": "true",
   "description": "NodeJS examples showcasing the Speechmatics JS SDK",
   "type": "module",

--- a/examples/nodejs/real-time-file-example.ts
+++ b/examples/nodejs/real-time-file-example.ts
@@ -46,7 +46,7 @@ const jwt = await createSpeechmaticsJWT({
   ttl: 60, // 1 minute
 });
 
-const fileStream = fs.createReadStream('./Super_long.wav', {
+const fileStream = fs.createReadStream('./example.wav', {
   highWaterMark: 4096, // avoid sending too much data at once
 });
 

--- a/examples/nodejs/real-time-file-example.ts
+++ b/examples/nodejs/real-time-file-example.ts
@@ -46,8 +46,8 @@ const jwt = await createSpeechmaticsJWT({
   ttl: 60, // 1 minute
 });
 
-const fileStream = fs.createReadStream('./example.wav', {
-  highWaterMark: 4096, //avoid sending faster than realtime
+const fileStream = fs.createReadStream('./Super_long.wav', {
+  highWaterMark: 4096, // avoid sending too much data at once
 });
 
 await client.start(jwt, {
@@ -64,5 +64,7 @@ fileStream.on('data', (sample) => {
 
 //end the session
 fileStream.on('end', () => {
-  client.stopRecognition();
+  // Send a stop message to the server when we're done sending audio.
+  // We set `noTimeout` so that we can wait for all the data to be processed before closing the connection.
+  client.stopRecognition({ noTimeout: true });
 });

--- a/examples/nodejs/real-time-file-example.ts
+++ b/examples/nodejs/real-time-file-example.ts
@@ -65,6 +65,7 @@ fileStream.on('data', (sample) => {
 //end the session
 fileStream.on('end', () => {
   // Send a stop message to the server when we're done sending audio.
-  // We set `noTimeout` so that we can wait for all the data to be processed before closing the connection.
+  // We set `noTimeout` because we are streaming faster than real-time,
+  // so we should wait for all the data to be processed before closing the connection.
   client.stopRecognition({ noTimeout: true });
 });

--- a/packages/flow-client/package.json
+++ b/packages/flow-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechmatics/flow-client",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Javascript client for the Speechmatics Flow API",
   "main": "dist/index.js",
   "files": ["dist/", "README.md"],

--- a/packages/flow-client/src/client.ts
+++ b/packages/flow-client/src/client.ts
@@ -322,7 +322,7 @@ function rejectAfter(
         reject(
           new SpeechmaticsFlowError(
             'Timeout',
-            `Timed out after ${timeoutMs}s waiting for ${key}`,
+            `Timed out after ${timeoutMs}ms waiting for ${key}`,
           ),
         ),
       timeoutMs,

--- a/packages/real-time-client-react/package.json
+++ b/packages/real-time-client-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechmatics/real-time-client-react",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "React hooks for interacting with the Speechmatics Real-Time API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/real-time-client/package.json
+++ b/packages/real-time-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechmatics/real-time-client",
-  "version": "5.0.8",
+  "version": "5.0.9",
   "description": "Client for the Speechmatics real-time API",
   "main": "dist/index.js",
   "browser": "dist/index.browser.js",

--- a/packages/real-time-client/src/client.ts
+++ b/packages/real-time-client/src/client.ts
@@ -191,7 +191,7 @@ export class RealtimeClient extends TypedEventTarget<RealtimeClientEventMap> {
   ): Promise<RecognitionStarted> {
     await this.connect(jwt);
 
-    const waitForConversationStarted = new Promise<RecognitionStarted>(
+    const waitForRecognitionStarted = new Promise<RecognitionStarted>(
       (resolve, reject) => {
         this.addEventListener('receiveMessage', ({ data }) => {
           if (data.message === 'RecognitionStarted') {
@@ -214,7 +214,7 @@ export class RealtimeClient extends TypedEventTarget<RealtimeClientEventMap> {
     );
 
     return Promise.race([
-      waitForConversationStarted,
+      waitForRecognitionStarted,
       rejectAfter<RecognitionStarted>(
         RT_CLIENT_RESPONSE_TIMEOUT_MS,
         'RecognitionStarted',
@@ -223,7 +223,7 @@ export class RealtimeClient extends TypedEventTarget<RealtimeClientEventMap> {
   }
 
   /** Sends an `"EndOfStream"` message, resolving if acknowledged by an `"EndOfTranscript"` from server, rejecting if not received */
-  async stopRecognition() {
+  async stopRecognition({ noTimeout }: { noTimeout?: true } = {}) {
     const waitForEndOfTranscript = new Promise<void>((resolve) => {
       this.addEventListener('receiveMessage', ({ data }) => {
         if (data.message === 'EndOfTranscript') {
@@ -237,6 +237,10 @@ export class RealtimeClient extends TypedEventTarget<RealtimeClientEventMap> {
         last_seq_no: this.lastAudioAddedSeqNo,
       });
     });
+
+    if (noTimeout) {
+      return;
+    }
 
     return Promise.race([
       waitForEndOfTranscript,
@@ -279,7 +283,7 @@ function rejectAfter<T = unknown>(timeoutMs: number, key: string): Promise<T> {
       () =>
         reject(
           new SpeechmaticsRealtimeError(
-            `Timed out after ${timeoutMs}s waiting for ${key}`,
+            `Timed out after ${timeoutMs}ms waiting for ${key}`,
           ),
         ),
       timeoutMs,


### PR DESCRIPTION
Currently, the Node real-time example gives a timeout error when streaming files longer than 10 seconds. This is because we call `stopRecognition` when the data is finished streaming, but there is still audio/transcription being processed before the server disconnects.

This PR allows the user to specify `noTimeout`, to disable waiting for an `EndOfTranscript` message, facilitating faster-than-real-time use cases.

Additionally cleaning up error messages and bumping versions of changed packages.