### PR TITLE
Update RT spec: Add missing info session variant

### DIFF
--- a/packages/real-time-client-react/package.json
+++ b/packages/real-time-client-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechmatics/real-time-client-react",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "React hooks for interacting with the Speechmatics Real-Time API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/real-time-client/models/info.ts
+++ b/packages/real-time-client/models/info.ts
@@ -54,6 +54,18 @@ export interface Info {
    * @memberof Info
    */
   quality?: string;
+  /**
+   *
+   * @type {number}
+   * @memberof Info
+   */
+  usage?: number;
+  /**
+   *
+   * @type {number}
+   * @memberof Info
+   */
+  quota?: number;
 }
 
 export const InfoMessageEnum = {
@@ -66,6 +78,7 @@ export const InfoTypeEnum = {
   RecognitionQuality: 'recognition_quality',
   ModelRedirect: 'model_redirect',
   Deprecated: 'deprecated',
+  ConcurrentSessionUsage: 'concurrent_session_usage',
 } as const;
 
 export type InfoTypeEnum = (typeof InfoTypeEnum)[keyof typeof InfoTypeEnum];

--- a/packages/real-time-client/package.json
+++ b/packages/real-time-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechmatics/real-time-client",
-  "version": "5.0.9",
+  "version": "5.0.10",
   "description": "Client for the Speechmatics real-time API",
   "main": "dist/index.js",
   "browser": "dist/index.browser.js",

--- a/packages/real-time-client/schema/realtime.yml
+++ b/packages/real-time-client/schema/realtime.yml
@@ -295,6 +295,7 @@ components:
               - recognition_quality
               - model_redirect
               - deprecated
+              - concurrent_session_usage
           reason:
             type: string
           code:
@@ -303,6 +304,11 @@ components:
             type: integer
           quality:
             type: string
+          # usage and quota defined for concurrent_session_usage messages
+          usage:
+            type: number
+          quota:
+            type: number
         required:
           - message
           - type

--- a/packages/real-time-client/scripts/generate-models.sh
+++ b/packages/real-time-client/scripts/generate-models.sh
@@ -6,7 +6,7 @@ PROJECT_ROOT=${SCRIPT_DIR}/..
 # Get a 'fake' openapi spec from the async realtime-api spec (we just need the schemas)
 pnpm tsx ${SCRIPT_DIR}/transform-async-to-openapi.ts
 
-openapi-generator generate -i ${SCRIPT_DIR}/openapi-transformed.yaml -g typescript-axios --global-property models  -o ${PROJECT_ROOT}/ -c ${SCRIPT_DIR}/../schema/autogen.json
+pnpm openapi-generator-cli generate -i ${SCRIPT_DIR}/openapi-transformed.yaml -g typescript-axios --global-property models  -o ${PROJECT_ROOT}/ -c ${SCRIPT_DIR}/../schema/autogen.json
 
 cd $PROJECT_ROOT/models;
 

--- a/packages/real-time-client/scripts/openapi-transformed.yaml
+++ b/packages/real-time-client/scripts/openapi-transformed.yaml
@@ -217,6 +217,7 @@ components:
             - recognition_quality
             - model_redirect
             - deprecated
+            - concurrent_session_usage
         reason:
           type: string
         code:
@@ -225,6 +226,10 @@ components:
           type: integer
         quality:
           type: string
+        usage:
+          type: number
+        quota:
+          type: number
       required:
         - message
         - type


### PR DESCRIPTION
- Add missing [`concurrent_session_usage`](https://docs.speechmatics.com/rt-api-ref#info) message to spec and types
- Fix openapi generation script