### PR TITLE
Fix broken RT example

### DIFF
--- a/examples/nextjs-real-time-transcription/app/page.tsx
+++ b/examples/nextjs-real-time-transcription/app/page.tsx
@@ -15,10 +15,12 @@ export const metadata: Metadata = {
 
 export default async function Page() {
   const features = await getFeatures();
-  const displayNames = new Intl.DisplayNames(['en'], { type: 'language' });
-  const languages = features.realtime.transcription[0].languages.map(
-    (code) => [code, displayNames.of(code) ?? code] as const,
-  );
+  const languages = features.realtime.transcription[0].languages.map((code) => {
+    return [
+      code,
+      features.metadata.language_pack_info[code]?.language_description,
+    ] as const;
+  });
 
   return (
     <AudioProvider>

--- a/examples/nextjs-real-time-transcription/components/Output.tsx
+++ b/examples/nextjs-real-time-transcription/components/Output.tsx
@@ -7,7 +7,7 @@ import {
 import { ErrorBoundary } from 'react-error-boundary';
 import { ErrorFallback } from './ErrorFallback';
 import { AudioVisualizer } from './AudioVisualizer';
-import { usePCMAudioRecorder } from '@speechmatics/browser-audio-input-react';
+import { usePCMAudioRecorderContext } from '@speechmatics/browser-audio-input-react';
 
 export function Output() {
   return (
@@ -21,7 +21,7 @@ export function Component() {
   const [transcription, dispatch] = useReducer(transcriptReducer, []);
 
   useRealtimeEventListener('receiveMessage', (e) => dispatch(e.data));
-  const { analyser } = usePCMAudioRecorder();
+  const { analyser } = usePCMAudioRecorderContext();
 
   return (
     <article>


### PR DESCRIPTION
- Fix call to `usePCMAudioRecorder` without context
- Fix language display names (broken since `en_ta` was added, which is not ISO compliant)