### PR TITLE
browser-audio-input: cleanup media stream after permission prompt

### DIFF
--- a/packages/browser-audio-input-react/package.json
+++ b/packages/browser-audio-input-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechmatics/browser-audio-input-react",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "React hooks for managing audio inputs and permissions across browsers",
   "type": "module",
   "exports": ["./dist/index.js"],

--- a/packages/browser-audio-input/package.json
+++ b/packages/browser-audio-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechmatics/browser-audio-input",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Manage audio input devices and persmissions across browsers",
   "exports": {
     ".": "./dist/index.js",

--- a/packages/browser-audio-input/src/devices.ts
+++ b/packages/browser-audio-input/src/devices.ts
@@ -65,8 +65,9 @@ export class AudioInputDevicesStore extends TypedEventTarget<AudioInputDevicesEv
     if (this.permissionState !== 'prompt') return;
 
     this.permissionState = 'prompting';
+    let mediaStream: MediaStream | null = null;
     try {
-      const mediaStream = await navigator.mediaDevices.getUserMedia({
+      mediaStream = await navigator.mediaDevices.getUserMedia({
         audio: true,
         video: false,
       });
@@ -75,6 +76,12 @@ export class AudioInputDevicesStore extends TypedEventTarget<AudioInputDevicesEv
       }
     } catch (e) {
       this.permissionState = 'denied';
+    } finally {
+      if (mediaStream) {
+        for (const track of mediaStream.getTracks()) {
+          track.stop();
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Clean up media stream after prompting for device permission. For more context, see issue: https://github.com/speechmatics/speechmatics-js-sdk/issues/128