### PR TITLE
`browser-audio-input`:  Remove tracks from `mediaStream` on cleanup

### DIFF
--- a/packages/browser-audio-input-react/package.json
+++ b/packages/browser-audio-input-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechmatics/browser-audio-input-react",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "React hooks for managing audio inputs and permissions across browsers",
   "type": "module",
   "exports": ["./dist/index.js"],

--- a/packages/browser-audio-input/package.json
+++ b/packages/browser-audio-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechmatics/browser-audio-input",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Manage audio input devices and persmissions across browsers",
   "exports": {
     ".": "./dist/index.js",

--- a/packages/browser-audio-input/src/pcm-recorder.ts
+++ b/packages/browser-audio-input/src/pcm-recorder.ts
@@ -141,9 +141,10 @@ export class PCMRecorder extends TypedEventTarget<PCMRecorderEventMap> {
     if (this.mediaStream) {
       for (const track of this.mediaStream.getTracks()) {
         track.stop();
+        this.mediaStream?.removeTrack(track);
       }
-      this.inputSourceNode?.disconnect();
       this.workletProcessorNode?.port.postMessage('stop');
+      this.inputSourceNode?.disconnect();
       this.workletProcessorNode?.disconnect();
 
       this.mediaStream = undefined;


### PR DESCRIPTION
Remove tracks from `mediaStream` in addition to stopping on cleanup. This removes the microphone indicator in Safari after recording stops