### PR TITLE
Real-time client: Add missing `type: "object"` to schema items

### DIFF
--- a/packages/real-time-client-react/package.json
+++ b/packages/real-time-client-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechmatics/real-time-client-react",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "React hooks for interacting with the Speechmatics Real-Time API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/real-time-client/models/TranscriptFilteringConfig.ts
+++ b/packages/real-time-client/models/TranscriptFilteringConfig.ts
@@ -1,5 +1,9 @@
+import type { WordReplacementItem } from './WordReplacementItem';
 interface TranscriptFilteringConfig {
   remove_disfluencies?: boolean;
-  replacements?: boolean;
+  /**
+   * A list of replacement rules to apply to the transcript. Each rule consists of a pattern to match and a replacement string.
+   */
+  replacements?: WordReplacementItem[][];
 }
 export type { TranscriptFilteringConfig };

--- a/packages/real-time-client/models/WordReplacementItem.ts
+++ b/packages/real-time-client/models/WordReplacementItem.ts
@@ -1,0 +1,5 @@
+interface WordReplacementItem {
+  from: string;
+  to: string;
+}
+export type { WordReplacementItem };

--- a/packages/real-time-client/models/index.ts
+++ b/packages/real-time-client/models/index.ts
@@ -11,6 +11,7 @@ export * from './MaxDelayModeConfig';
 export * from './SpeakerDiarizationConfig';
 export * from './AudioFilteringConfig';
 export * from './TranscriptFilteringConfig';
+export * from './WordReplacementItem';
 export * from './OperatingPoint';
 export * from './PunctuationOverrides';
 export * from './ConversationConfig';

--- a/packages/real-time-client/package.json
+++ b/packages/real-time-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechmatics/real-time-client",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Client for the Speechmatics real-time API",
   "main": "dist/index.js",
   "browser": "dist/index.browser.js",

--- a/packages/real-time-client/schema/realtime.yml
+++ b/packages/real-time-client/schema/realtime.yml
@@ -554,6 +554,7 @@ components:
       items:
         $ref: "#/components/schemas/VocabWord"
     VocabWord:
+      type: object
       oneOf:
         - type: string
           minLength: 1
@@ -601,6 +602,7 @@ components:
           minimum: 0
           maximum: 100
     TranscriptFilteringConfig:
+      type: object
       properties:
         remove_disfluencies:
           type: boolean
@@ -701,11 +703,12 @@ components:
         - content
         - confidence
     RecognitionDisplay:
-      required:
-        - direction
+      type: object
       properties:
         direction:
           $ref: "#/components/schemas/DirectionEnum"
+      required:
+        - direction
     MaxDelayModeConfig:
       type: string
       enum:


### PR DESCRIPTION
- Add `type: "object"` to all schema items which either:
  - have `properties` defined
  - are a `oneOf` with variants which have `properties`
- Re-run model generation 