### PR TITLE
browser-audio-input: handle missing permissions (#171)

### DIFF
--- a/packages/browser-audio-input/src/devices.ts
+++ b/packages/browser-audio-input/src/devices.ts
@@ -39,10 +39,13 @@ export class AudioInputDevicesStore extends TypedEventTarget<AudioInputDevicesEv
       this.updateDeviceList();
     });
 
+    if (!navigator.permissions) {
+      console.warn('browser does not support microphone permissions query');
+    }
     // Link permissions API
     navigator.permissions
       // @ts-ignore: "microphone" isn't a supported PermissionName for all browsers
-      .query({ name: 'microphone' })
+      ?.query({ name: 'microphone' })
       .then((permissionStatus) => {
         this.permissionState = permissionStatus.state;
         permissionStatus.addEventListener('change', () => {


### PR DESCRIPTION
Checks for and handles missing navigator.permissions object in older browsers.

Fix #171