### PR TITLE
Add minified build target for `real-time-client`

### DIFF
--- a/packages/real-time-client/package.json
+++ b/packages/real-time-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechmatics/real-time-client",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "description": "Client for the Speechmatics real-time API",
   "main": "dist/index.js",
   "browser": "dist/index.browser.js",

--- a/packages/real-time-client/rollup.config.mjs
+++ b/packages/real-time-client/rollup.config.mjs
@@ -44,6 +44,24 @@ export default function rollup() {
     ],
   };
 
+  const minified = {
+    plugins: [
+      esbuild({
+        minify: true,
+        optimizeDeps: {
+          include: ['typescript-event-target'],
+        },
+      }),
+    ],
+    input: 'src/index.ts',
+    output: {
+      file: packageJSON.module.replace(/\.js$/, '.min.js'),
+      name: 'BrowserAudioInput',
+      format: 'umd',
+      strict: false,
+    },
+  };
+
   const typeDefinitions = {
     plugins: [
       dts({

--- a/packages/real-time-client/rollup.config.mjs
+++ b/packages/real-time-client/rollup.config.mjs
@@ -76,5 +76,5 @@ export default function rollup() {
     },
   };
 
-  return [browserESM, nodeCJS, typeDefinitions];
+  return [browserESM, nodeCJS, minified, typeDefinitions];
 }


### PR DESCRIPTION
Allows the `@speechmatics/real-time-client` to be consumed directly from the browser via CDN, similar to `@speechmatics/browser-audio-input`