### PR TITLE
Enable trusted publish for NPM packages

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       matrix:
         node-version: [22]
@@ -25,6 +28,4 @@ jobs:
       - name: Build packages
         run: pnpm build:packages
       - name: Publish all packages
-        run: pnpm config set '//registry.npmjs.org/:_authToken' "${NODE_AUTH_TOKEN}" && pnpm publish:packages
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
+        run: pnpm publish:packages

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint:check": "biome lint .",
 
     "build:packages": "pnpm --filter '{packages/*}' build",
-    "publish:packages": "pnpm --filter '{packages/*}' publish --access=public"
+    "publish:packages": "pnpm --filter '{packages/*}' publish --access=public --provenance"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Background

NPM now recommends Trusted Publish from Github in favour of access tokens: https://docs.npmjs.com/trusted-publishers. This PR updates the existing publishing workflow to enable the necessary OIDC exchange, making publishing more secure.

## Changes

- Remove NPM auth token from `cd.yml`
-  Add `--provenance` tag to the publish command
